### PR TITLE
Fix chrono wasm-bindgen dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,12 @@ crate-type = ["cdylib"]
 [dependencies]
 flawless = "1.0.0-alpha.16"
 flawless-http = "1.0.0-alpha.16"
-chrono = { version = "0.4.31", features = ["serde"] }
 serde = { version = "1.0.195", features = ["derive"] }
 url = { version = "2.5.0", features = [] }
 serde_json = { version = "1.0.111", features = [] }
 diff = "0.1.13"
+
+chrono = { version = "0.4.31", default-features = false, features = [
+    "serde",
+    "clock",
+] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN \
   --mount=type=ssh \
   mkdir -p /root/.cargo/bin/ && \
   rustup target add wasm32-unknown-unknown && \
-  cargo install flawless --version 1.0.0-alpha.10 --features="cargo-flw"
+  cargo install flawless --version 1.0.0-alpha.16 --features="cargo-flw"
 
 EXPOSE 8080/tcp
 EXPOSE 27288/tcp
@@ -17,4 +17,4 @@ ENTRYPOINT ["/root/.cargo/bin/flawless", "up"]
 
 
 FROM builder
-ENTRYPOINT ["cargo", "flw", "run", "risk_central", "--input", "{\"vat_code\":\"01234567890\",\"ndg\":\"333444\"}"]
+ENTRYPOINT ["cargo", "flw", "run", "risk-central", "--input", "{\"vat_code\":\"01234567890\",\"ndg\":\"333444\"}"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use std::thread::sleep;
 use std::time::Duration;
 
-use chrono::NaiveDate;
+use chrono::{DateTime, Local, NaiveDate};
 use flawless::workflow;
 use flawless_http::{get, post};
 use serde::{Deserialize, Serialize};
@@ -37,7 +37,7 @@ pub fn risk_central(input: Input) {
 #[derive(Debug, Serialize, Deserialize)]
 struct Input {
     ndg: String,
-    tax_code: String,
+    vat_code: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -59,7 +59,8 @@ trait IsRecent {
 
 impl IsRecent for NaiveDate {
     fn is_recent(&self) -> bool {
-        let today = chrono::offset::Local::now().naive_local().date();
+        let today: DateTime<Local> = flawless::time::now().into();
+        let today = today.naive_local().date();
         let diff = today.signed_duration_since(*self).num_days();
         diff < 30
     }
@@ -68,6 +69,5 @@ impl IsRecent for NaiveDate {
 #[cfg(test)]
 mod tests {
     #[test]
-    fn it_works() {
-    }
+    fn it_works() {}
 }


### PR DESCRIPTION
The `wasm-bindgen` issue is caused by `chrono`. This happens often when using crates compiled to wasm in non-browser environments. Flawless has a tool, `cargo flw check` to check for this kind of issues:

<img width="1099" alt="Screenshot 2024-03-18 at 11 16 07" src="https://github.com/albx79/rischialess/assets/593393/6e4df054-ad12-4629-87fd-51dc77261069">

By following the tip and disabling the default features, the workflow starts! 🎉

This PR also contains a few other small fixes:

- updates flawless version in the Dockerfile
- fixes workflow name in the Dockerfile
- uses the `now` function from flawless, `chrono` uses stdlib and this is not implemented and panics when compiling to wasm.